### PR TITLE
Added custom screen stretch

### DIFF
--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -643,6 +643,8 @@ bool settingsUpdateAllSettings(bool updateGameSettings = true)
 {
     bool settingsChanged = false;
 
+// StretchWidth and StretchHeight are now set directly in the cfg, for custom screen size.
+/*
     // update screen stretch
     //
     if (settings3DS.ScreenStretch == 0)
@@ -694,6 +696,7 @@ bool settingsUpdateAllSettings(bool updateGameSettings = true)
         settings3DS.StretchHeight = 240;
         settings3DS.CropPixels = 0;
     }
+*/
 
     // Update the screen font
     //
@@ -853,6 +856,9 @@ bool settingsReadWriteFullListGlobal(bool writeMode)
     config3dsReadWriteInt32("# Do not modify this file or risk losing your settings.\n", NULL, 0, 0);
 
     config3dsReadWriteInt32("ScreenStretch=%d\n", &settings3DS.ScreenStretch, 0, 7);
+    config3dsReadWriteInt32("StretchWidth=%d\n", &settings3DS.StretchWidth, 0, 400);
+    config3dsReadWriteInt32("StretchHeight=%d\n", &settings3DS.StretchHeight, -1, 240);
+    config3dsReadWriteInt32("CropPixels=%d\n", &settings3DS.CropPixels, 0, 120);
     config3dsReadWriteInt32("HideUnnecessaryBottomScrText=%d\n", &settings3DS.HideUnnecessaryBottomScrText, 0, 1);
     config3dsReadWriteInt32("Font=%d\n", &settings3DS.Font, 0, 2);
 

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -58,8 +58,9 @@ typedef struct
 
     EmulatedFramerate ForceFrameRate = EmulatedFramerate::UseRomRegion;
 
-    int     StretchWidth, StretchHeight;
-    int     CropPixels;
+    int     StretchWidth = 400;
+    int     StretchHeight = 240;
+    int     CropPixels = 0;                 // crop pixels from each side by specified number
 
     int     Turbo[8] = {0, 0, 0, 0, 0, 0, 0, 0};  // Turbo buttons: 0 - No turbo, 1 - Release/Press every alt frame.
                                             // Indexes: 0 - A, 1 - B, 2 - X, 3 - Y, 4 - L, 5 - R


### PR DESCRIPTION
Adding custom stretch to snes9x was much simpler than VirtuaNES. snes9x still uses StretchWidth/StretchHeight variables that get set to different values based on the ScreenStretch setting used. So pretty much all we have to do is disable the ScreenStretch setting part and add the vars to the cfg:

```
StretchWidth=400
StretchHeight=240
CropPixels=0
```

CropPixels crops the specified number of pixels from *all* sides of the screen, not just top/bottom, so it has limited use. It doesn't seem that hard to change it if needed, but eh, SNES games don't seem to have overscan garbage, so they don't benefit from cropping as much as NES games.

---

For a pixel perfect image, you would want to set StretchWidth to 256, and StretchHeight to **223**. Setting it to 224 stretches the image and causes blurring. Kinda weird, not super sure why this is.

Alternatively, -1 is a special StretchHeight value that uses the SNES_HEIGHT value:

```
int sHeight = (settings3DS.StretchHeight **== -1 ? PPU.ScreenHeight - 1** : settings3DS.StretchHeight);
```

-1 might actually be the preferred value for pixel perfect, because PPU.ScreenHeight will automatically get set to SNES_HEIGHT_EXTENDED if an extended height (240) game is being played.

---

That's about it. We can change the cropping behavior, or else this should be good to go.